### PR TITLE
added Proxy-Authorization header

### DIFF
--- a/lib/client/digest-client.js
+++ b/lib/client/digest-client.js
@@ -19,7 +19,7 @@ module.exports = DigestClient ;
 
 DigestClient.prototype.authenticate = function(callback) {
   var self = this ;
-  var options = this.req._originalParams.options ;  
+  var options = this.req._originalParams.options ;
 
   // get the username and password - either provided directly or via a callback
   var fn ;
@@ -35,13 +35,13 @@ DigestClient.prototype.authenticate = function(callback) {
 
   // note: we pass the original request and the 401 (or whatever) response in case the caller wants to see it
   fn( this.req, this.res, function(err, username, password) {
-    if( err ) { 
-      return callback( err ); 
+    if( err ) {
+      return callback( err );
     }
 
     var header = self.res.statusCode === 407 ? 'proxy-authenticate' : 'www-authenticate' ;
     var challenge = parseChallenge(self.res.get(header));
-    
+
     var ha1 = crypto.createHash('md5');
     ha1.update([username, challenge.realm, password].join(':'));
     var ha2 = crypto.createHash('md5');
@@ -102,7 +102,10 @@ DigestClient.prototype.authenticate = function(callback) {
       authParams.cnonce = cnonce;
     }
 
-    headers.Authorization = compileParams(authParams);
+    self.res.statusCode === 407 ?
+      headers['Proxy-Authorization'] = compileParams(authParams) :
+      headers['Authorization'] = compileParams(authParams);
+      
     options.headers = headers;
 
     self.agent.request(options, callback ) ;


### PR DESCRIPTION
I needed to add the option to use a Proxy-Authorization header if the challenge was 'Proxy-Authenticate'; otherwise Freeswitch would continue to sent 407 challenge to drachtio's response with credentials. The RFC section on the Proxy-Authorization is here:
 [https://tools.ietf.org/html/rfc3261#section-22.3](https://tools.ietf.org/html/rfc3261#section-22.3).