### PR TITLE
Upping sip-methods reference to latest version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "merge": "^1.1.3",
     "node-noop": "0.0.1",
     "only": "0.0.2",
-    "sip-methods": "^0.1.0",
+    "sip-methods": "^0.3.0",
     "sip-status": "~0.1.0",
     "utils-merge": "1.0.0",
     "uuid": "^3.0.1",


### PR DESCRIPTION
SIP PUBLISH exposure was recently added to drachtio-server and sip-methods. This fixes the reference to the latest sip-methods package so that the API can be accessed.